### PR TITLE
Add memory requirements to README an --no-cache to dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ GUI appearance and behavior, and client-server communication.
 YANG Suite can be installed as a Docker container or through Python
 package management.  Docker-compose is the recommended install.
 
+Requires about 3.5GB of memory to load large Cisco native models.
+
 Docker Installation
 -------------------
 

--- a/docker/yangsuite/dockerfile
+++ b/docker/yangsuite/dockerfile
@@ -21,24 +21,24 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip setuptools
+RUN pip3 install --upgrade pip setuptools wheel
 RUN mkdir -p /yangsuite/uwsgi
 COPY uwsgi.ini /yangsuite/
 COPY migrate_and_start.sh /yangsuite/
 RUN pip3 install --upgrade pip
 
 # Installing YANG Suite
-RUN pip3 install --upgrade yangsuite[core] uwsgi
+RUN pip3 install --upgrade --no-cache yangsuite[core] uwsgi
 
-# Add another pypi repository to search for here
+# Uncomment to add another pypi repository to search for here
 #
 # ARG PIP_EXTRA_URL=https://private.pypi.com/simple
-# RUN pip3 install --upgrade --extra-index-url=${PIP_EXTRA_URL} yangsuite[core] uwsgi
+# RUN pip3 install --upgrade --no-cache --extra-index-url=${PIP_EXTRA_URL} yangsuite[core] uwsgi
 
-# Install optional plugin or replacement wheels
+# Uncomment to install optional plugin or replacement wheels
 #
 # COPY *.whl /yangsuite/
-# RUN pip3 install --upgrade /yangsuite/*.whl
+# RUN pip3 install --upgrade --no-cache /yangsuite/*.whl
 
 COPY production.py ${YS_SETTINGS}
 COPY wsgi.py ${YS_DIST}


### PR DESCRIPTION
3.5GB needed for large Cisco models.
The pip install of yangsuite[core] will not update if packages are in cache so added ``--no-cache``.