### PR TITLE
add check for docker cli version in start script

### DIFF
--- a/docker/start_yang_suite.sh
+++ b/docker/start_yang_suite.sh
@@ -93,6 +93,10 @@ YS_ADMIN_PASS=$PASS_ONE
 YS_ADMIN_EMAIL=$ADMIN_EMAIL
 %%
 
-docker-compose up --build
-# Someone should fix this to make it better, do some checking first plz!
-docker compose up --build
+# Check for docker-compose CLI, redirect stdout & stderr
+if docker-compose -v >/dev/null 2>&1; then
+    docker-compose up --build
+# Check for docker compose V2 CLI, redirect stdout & stderr
+elif docker compose version >/dev/null 2>&1; then
+    docker compose up --build
+fi


### PR DESCRIPTION
Added check for docker-compose and docker compose CLI. Tested on macOS and Linux (Amazon Linux 2), docker-compose and docker compose.