### PR TITLE
Address Remote access issues 

### DIFF
--- a/docker/start_yang_suite.sh
+++ b/docker/start_yang_suite.sh
@@ -29,6 +29,19 @@ then
     die
 fi
 
+echo -n "Will you access the system from a remote host? (y/n): "
+read -r
+REMOTE=$REPLY
+
+if [ "${REMOTE}" == "y" ]
+then
+    echo -n "Enter FQDN or IP: "
+    read -r
+    ALLOWED_HOSTS=$REPLY
+else
+    ALLOWED_HOSTS="localhost"
+fi
+
 echo -n "email: "
 read -r
 ADMIN_EMAIL=$REPLY
@@ -87,7 +100,7 @@ DJANGO_SETTINGS_MODULE=yangsuite.settings.production
 MEDIA_ROOT=/ys-data/
 STATIC_ROOT=/ys-static/
 DJANGO_STATIC_ROOT=/ys-static/
-DJANGO_ALLOWED_HOSTS=localhost
+DJANGO_ALLOWED_HOSTS=$ALLOWED_HOSTS
 YS_ADMIN_USER=$ADMIN_USER
 YS_ADMIN_PASS=$PASS_ONE
 YS_ADMIN_EMAIL=$ADMIN_EMAIL

--- a/docker/start_yang_suite.sh
+++ b/docker/start_yang_suite.sh
@@ -35,7 +35,7 @@ REMOTE=$REPLY
 
 if [ "${REMOTE}" == "y" ]
 then
-    echo -n "Enter FQDN or IP: "
+    echo -n "Enter local host FQDN or IP: "
     read -r
     ALLOWED_HOSTS=$REPLY
 else


### PR DESCRIPTION
This pull request is to address an error when accessing yangsuite web frontend from a remote host. 

Error received:
`docker-yangsuite-1  | [31/Jan/2023 10:27:50] ERROR [django.security.DisallowedHost:75] Invalid HTTP_HOST header: 'enauto.homelab.com:8443'. You may need to add 'enauto.homelab.com' to ALLOWED_HOSTS.`

Pull request added a user prompt to understand if the system will be accessed remotely, if yes add host fqdn or ip to yangsuite/setup.env and if no leave it as localhost

This is my first pull request so please provide any feedback.

Steele