### PR TITLE
Small tweak to "Quick Start with PIP Install on MacOS" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ pyenv install 3.8
 Now that the correct and YANG Suite-supported version of Python 3.8 is installed, create and activate the virtual environment
 
 ```
-~/.pyenv/versions/3.8.12/bin/python -m venv yangsuitevenv
-source yangsuiteenv/bin/activate
+~/.pyenv/versions/3.8.19/bin/python -m venv yangsuitevenv
+source yangsuitevenv/bin/activate
 ```
 
 Next, install the YANG Suite tool within the virutal evnrionment using pip:


### PR DESCRIPTION
Updated the python version in the example to 3.8.19 to align with that "pyenv install 3.8" pulls as of today. 

Also, fixed typo in the next command, as a "v" was missing. Before "yangsuiteenv", now "yangsuitevenv"