### PR TITLE
Adding one-container-alternative to install Yang Suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ playground.xcworkspace
 *.swp
 *~
 .DS_Store
+
+# don't commit the user certificates
+one-container-alternative/certificate/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ To use the resources in this repository, you must install Docker on the system w
 
 ## Quick Start with Docker:
 
+> [!NOTE]
+> For quick exploring, see the [one-container-alternative](/one-container-alternative/) directory where you can find an alternative way to install YANG Suite using a single container with no user input required.
+
 1. Clone this repository
 
 2. Run start_yang_suite.sh or, 

--- a/one-container-alternative/Dockerfile
+++ b/one-container-alternative/Dockerfile
@@ -1,0 +1,104 @@
+ARG PY_VERSION=3.10
+
+# Base image used for all stages
+FROM python:${PY_VERSION} as base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+    && apt-get install -yq \
+      inotify-tools \
+      iputils-ping \
+      lsb-release \
+      net-tools \
+      postgresql \
+      sendmail \
+      snmp \
+      tree \
+      vim \
+    && apt-get clean \
+    && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+
+# stage for python dependencies
+FROM base as python_dependencies
+
+ARG PYTHONUNBUFFERED=1
+ARG PIP_NO_CACHE_DIR=off
+ARG PIP_NO_WARN_SCRIPT_LOCATION=0
+ARG PIP_DISABLE_ROOT_WARNING=ignore
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+
+COPY python_dependencies/requirements.txt /tmp/requirements.txt
+
+RUN pip install --upgrade -r /tmp/requirements.txt 
+
+
+# stage for yangsuite setup
+FROM python_dependencies as app_setup
+
+EXPOSE 443 3000 8080 8086 8443 8480 9339 50051 50052 57344 57345
+
+ARG YS_ADMIN_USER=developer
+ARG YS_ADMIN_PASS=developer
+ARG YS_ADMIN_EMAIL=developer@example.com
+
+ENV DOCKER_RUN=true \
+    MEDIA_ROOT=/ys-data/ \
+    STATIC_ROOT=/ys-static/ \
+    ALLOWED_HOSTS=localhost \
+    YS_ADMIN_USER=${YS_ADMIN_USER} \
+    YS_ADMIN_PASS=${YS_ADMIN_PASS} \
+    YS_ADMIN_EMAIL=${YS_ADMIN_EMAIL} \
+    DJANGO_SETTINGS_MODULE=yangsuite.settings.production
+    
+ENV DJANGO_STATIC_ROOT=${STATIC_ROOT} \
+    DJANGO_ALLOWED_HOSTS=${ALLOWED_HOSTS} 
+
+COPY build-assets/ /build-assets
+
+RUN groupadd --gid 1000 developer \
+    && useradd \
+        --create-home \
+        --home-dir /home/developer \
+        --no-user-group \
+        --no-log-init  \
+        --groups developer  \
+        --shell /bin/bash developer \
+    && echo 'alias ll="ls -al"' >> /root/.bashrc \
+    && echo 'alias ll="ls -al"' >> /home/developer/.bashrc \
+    && mkdir -p ${MEDIA_ROOT} \
+    && mkdir -p ${STATIC_ROOT} \
+    && mkdir -p /certificate \
+    && chmod u+s /bin/ping \
+    && chmod +x /build-assets/start_daphne.sh \
+    && chmod +x /build-assets/monitor_logs.sh \
+    && chmod +x /build-assets/pick_certificate.sh \
+    && chmod +x /build-assets/start_environment.sh \
+    && chmod +x /build-assets/migrate_and_start.sh \
+    && chmod +x /build-assets/validate_certificate.sh \
+    && chmod +x /build-assets/create_self_signed_cert.sh \
+    && ./build-assets/create_self_signed_cert.sh \
+    && ln -snf /usr/share/zoneinfo/${CONTAINER_TIMEZONE} /etc/localtime \
+    && echo ${CONTAINER_TIMEZONE} > /etc/timezone \
+    && YS_DIR=$(pip show yangsuite | grep "^Location"|cut -d" " -f 2)/yangsuite \
+    && yangsuite \
+        --save-settings \
+        --configure-only \
+        --data-path ${MEDIA_ROOT} \
+        --static-root ${STATIC_ROOT} \
+        --allowed-hosts ${ALLOWED_HOSTS} \
+        --settings yangsuite.settings.production \
+    && chown -R developer:developer \
+        /var/run/ \
+        /var/log/ \
+        /certificate \
+        ${MEDIA_ROOT} \
+        ${STATIC_ROOT} \
+        /build-assets/ \
+        ${YS_DIR}
+
+USER developer
+
+ENTRYPOINT ["/build-assets/start_environment.sh"]
+CMD tail -f /dev/null 

--- a/one-container-alternative/Dockerfile
+++ b/one-container-alternative/Dockerfile
@@ -37,7 +37,7 @@ RUN pip install --upgrade -r /tmp/requirements.txt
 # stage for yangsuite setup
 FROM python_dependencies as app_setup
 
-EXPOSE 443 3000 8080 8086 8443 8480 9339 50051 50052 57344 57345
+EXPOSE 8480 57500 57501
 
 ARG YS_ADMIN_USER=developer
 ARG YS_ADMIN_PASS=developer
@@ -46,7 +46,7 @@ ARG YS_ADMIN_EMAIL=developer@example.com
 ENV DOCKER_RUN=true \
     MEDIA_ROOT=/ys-data/ \
     STATIC_ROOT=/ys-static/ \
-    ALLOWED_HOSTS=localhost \
+    ALLOWED_HOSTS='*' \
     YS_ADMIN_USER=${YS_ADMIN_USER} \
     YS_ADMIN_PASS=${YS_ADMIN_PASS} \
     YS_ADMIN_EMAIL=${YS_ADMIN_EMAIL} \
@@ -81,7 +81,7 @@ RUN groupadd --gid 1000 developer \
     && ./build-assets/create_self_signed_cert.sh \
     && ln -snf /usr/share/zoneinfo/${CONTAINER_TIMEZONE} /etc/localtime \
     && echo ${CONTAINER_TIMEZONE} > /etc/timezone \
-    && YS_DIR=$(pip show yangsuite | grep "^Location"|cut -d" " -f 2)/yangsuite \
+    && YS_DIR=$(pip show yangsuite | grep "^Location"|cut -d" " -f 2)/ \
     && yangsuite \
         --save-settings \
         --configure-only \
@@ -90,15 +90,13 @@ RUN groupadd --gid 1000 developer \
         --allowed-hosts ${ALLOWED_HOSTS} \
         --settings yangsuite.settings.production \
     && chown -R developer:developer \
+        ${YS_DIR} \
         /var/run/ \
         /var/log/ \
         /certificate \
         ${MEDIA_ROOT} \
         ${STATIC_ROOT} \
-        /build-assets/ \
-        ${YS_DIR}
-
-USER developer
+        /build-assets/ 
 
 ENTRYPOINT ["/build-assets/start_environment.sh"]
 CMD tail -f /dev/null 

--- a/one-container-alternative/Makefile
+++ b/one-container-alternative/Makefile
@@ -2,7 +2,7 @@ build:
 	docker build --target app_setup --platform linux/$$(uname -m | sed 's/arm64/arm64/g' | sed 's/x86_64/amd64/g') -t yangsuite-one-container .
 
 run:
-	docker run -itd --name yangsuite-one-container -v ./certificate:/certificate -v yangsuite-one-container-data:/ys-data --memory 4096m --memory-swap 4096m -p 443:443 -p 3000:3000 -p 8080:8080 -p 8086:8086 -p 8443:8443 -p 8480:8480 -p 9339:9339 -p 50051:50051 -p 50052:50052 -p 57344:57344 -p 57345:57345 -u developer yangsuite-one-container
+	docker run -itd --name yangsuite-one-container -v ./certificate:/certificate -v yangsuite-one-container-data:/ys-data --memory 4096m --memory-swap 4096m -p 8480:8480 -p 57500:57500 -p 57501:57501 -u root yangsuite-one-container
 
 start:
 	docker start yangsuite-one-container

--- a/one-container-alternative/Makefile
+++ b/one-container-alternative/Makefile
@@ -1,0 +1,34 @@
+build:
+	docker build --target app_setup --platform linux/$$(uname -m | sed 's/arm64/arm64/g' | sed 's/x86_64/amd64/g') -t yangsuite-one-container .
+
+run:
+	docker run -itd --name yangsuite-one-container -v ./certificate:/certificate -v yangsuite-one-container-data:/ys-data --memory 4096m --memory-swap 4096m -p 443:443 -p 3000:3000 -p 8080:8080 -p 8086:8086 -p 8443:8443 -p 8480:8480 -p 9339:9339 -p 50051:50051 -p 50052:50052 -p 57344:57344 -p 57345:57345 -u developer yangsuite-one-container
+
+start:
+	docker start yangsuite-one-container
+
+stop:
+	docker stop yangsuite-one-container
+
+rm: 
+	-docker rm -f yangsuite-one-container
+
+rm-volume:
+	-docker volume rm yangsuite-one-container-data
+
+follow:
+	docker logs --follow yangsuite-one-container
+
+debug:
+	docker exec -it yangsuite-one-container sh -c '/build-assets/monitor_logs.sh'
+
+cli:
+	docker exec -it yangsuite-one-container /bin/bash
+
+dev:
+	$(MAKE) rm
+	$(MAKE) rm-volume
+	$(MAKE) build
+	$(MAKE) run
+	$(MAKE) follow
+	# $(MAKE) debug

--- a/one-container-alternative/README.md
+++ b/one-container-alternative/README.md
@@ -1,0 +1,92 @@
+# one-container-alternative
+
+This is an alternative way to install YANG Suite using only a single container instead of three.
+
+This alternative is intended for _experimentation_ and not as a direct replacement of the existing YANG Suite Docker implementation.
+
+## Advantages
+
+- Fewer points of failure. One container for all YANG Suite requirements.
+- No user input required. Configuration settings are preset.
+- No Docker Compose needed. Only Docker commands are used.
+- `nginx` Server removed.
+- You can provide your own certificates; otherwise, a self-signed (dummy) certificate will be used.
+- HTTPs only. Port `8480` used.
+- Container running as non-root user.
+
+## Limitations
+
+- No Backup cron job.
+
+## Prerequisites
+
+- `Docker`
+- `Make`
+
+## Build
+
+To start building the container, go to `one-container-alternative` directory first.
+
+```bash
+cd one-container-alternative
+```
+
+> [!IMPORTANT]
+> The rest of the commands assume you are executing the commands from inside the `one-container-alternative` directory.
+
+Then run:
+
+```bash
+make build
+```
+
+## Run
+
+To start YANG Suite and begin using it, run:
+
+```bash
+make run
+```
+
+Then visit <https://localhost:8480> (assuming that you are running it locally), accept the EULA, and use `developer/developer` to enter YANG Suite.
+
+The named volume `yangsuite-one-container-data` is used to store the YANG Suite `ys-data` directory, where settings and data are stored.
+
+You can also do `make stop` and `make start`, to `stop` and `start` the container respectively.
+
+## Using Custom Certificates
+
+You can provide your own SSL certificates by creating a `certificate` directory and placing your files in it. The [container looks](/one-container-alternative/build-assets/pick_certificate.sh#L5) for `.crt` and `.key` files in this directory. If both files are found, they will be used for `HTTPS`. If no user-provided certificates are found, the container [falls back to using self-signed](/one-container-alternative/build-assets/pick_certificate.sh#L21) (dummy) certificates.
+
+Steps to Use Custom Certificates.
+
+- Create a `certificate` directory (inside the `one-container-alternative` directory).
+- Place your `.crt` and `.key` files in the `certificate` directory.
+- Only one `.crt` and `.key` files are allowed.
+- Ensure that the filenames have the `.crt` and `.key` extensions.
+- Run the container using the `make run` command.
+
+## Development
+
+The `daphne` server handles HTTP requests, while `twisted` manages secure communications for the YANG Suite front end.
+
+You can pass the environment variables `YS_ADMIN_USER`, `YS_ADMIN_PASS`, and `YS_ADMIN_EMAIL`, to do so, adjust the `make build` command, so they are set at build time, and pass them as `build-arg`.
+
+## Logs
+
+You can watch YANG Suite Front end logs using:
+
+> [!TIP]
+> This is handy when you run along `run`, for example `make run follow`. Use `Ctrl + C` to stop the logs.
+
+```bash
+make follow
+```
+
+You can watch YANG Suite internal logs using:
+
+```bash
+make debug
+```
+
+See the other options available in the [Makefile.](./Makefile)

--- a/one-container-alternative/README.md
+++ b/one-container-alternative/README.md
@@ -12,11 +12,11 @@ This alternative is intended for _experimentation_ and not as a direct replaceme
 - `nginx` Server removed.
 - You can provide your own certificates; otherwise, a self-signed (dummy) certificate will be used.
 - HTTPs only. Port `8480` used.
-- Container running as non-root user.
 
 ## Limitations
 
 - No Backup cron job.
+- Container running as root. `/usr/local/bin/create_yangtree` had permissions issues. Will fix on a later release.
 
 ## Prerequisites
 

--- a/one-container-alternative/build-assets/create_self_signed_cert.sh
+++ b/one-container-alternative/build-assets/create_self_signed_cert.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Define variables
+CERT_DIR="/build-assets/self_signed_certificates/"
+PRIVATE_KEY="$CERT_DIR/private.key"
+CERTIFICATE="$CERT_DIR/certificate.crt"
+DAYS_VALID=1095
+
+# Create directory for certificates if it doesn't exist
+mkdir -p $CERT_DIR
+
+# Generate a private key
+openssl genpkey -algorithm RSA -out $PRIVATE_KEY -pkeyopt rsa_keygen_bits:2048
+
+# Generate a certificate signing request (CSR) with dummy data
+openssl req -new -key $PRIVATE_KEY -out "$CERT_DIR/request.csr" -subj "/C=XX/ST=SomeState/L=SomeCity/O=SomeOrganization/CN=dummy.com"
+
+# Generate a self-signed certificate
+openssl x509 -req -days $DAYS_VALID -in "$CERT_DIR/request.csr" -signkey $PRIVATE_KEY -out $CERTIFICATE
+
+# Clean up the CSR
+rm "$CERT_DIR/request.csr"
+
+echo "Self-signed certificate created at $CERTIFICATE"

--- a/one-container-alternative/build-assets/migrate_and_start.sh
+++ b/one-container-alternative/build-assets/migrate_and_start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Start the yanguite service in production.
+
+# Get the system yangsuite location
+PY=python3
+YS_DIR=$(pip show yangsuite | grep "^Location"|cut -d" " -f 2)/yangsuite
+
+cd $YS_DIR && \
+  ${PY} manage.py collectstatic --noinput && \
+  ${PY} manage.py makemigrations && \
+  ${PY} manage.py migrate
+
+if [ -z "${YS_ADMIN_USER}" ]
+then
+    echo "No ADMIN USER set"
+fi
+if [ -z "${YS_ADMIN_PASS}" ]
+then
+    echo "No ADMIN PASSWORD set"
+fi
+if [ -z "${YS_ADMIN_EMAIL}" ]
+then
+    echo "No ADMIN EMAIL set"
+fi
+
+echo "from django.contrib.auth.models import User; User.objects.create_superuser('${YS_ADMIN_USER}', '${YS_ADMIN_EMAIL}', '${YS_ADMIN_PASS}')" | ${PY} ${YS_DIR}/manage.py shell

--- a/one-container-alternative/build-assets/monitor_logs.sh
+++ b/one-container-alternative/build-assets/monitor_logs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+LOG_DIR="/ys-data/logs"
+INOTIFY_EVENTS="create,modify,delete,move"
+
+# Function to tail all current log files
+tail_logs() {
+  tail -F "$LOG_DIR"/* &
+  TAIL_PID=$!
+}
+
+# Function to clean up and exit
+cleanup() {
+  echo "Stopping log monitoring..."
+  kill $TAIL_PID
+  exit 0
+}
+
+# Trap termination signals
+trap cleanup SIGINT SIGTERM
+
+# Start tailing existing logs
+tail_logs
+
+# Monitor the directory for new files and restart tailing
+inotifywait -m -e "$INOTIFY_EVENTS" --format '%w%f' "$LOG_DIR" | while read NEW_FILE
+do
+  kill $TAIL_PID
+  tail_logs
+done

--- a/one-container-alternative/build-assets/pick_certificate.sh
+++ b/one-container-alternative/build-assets/pick_certificate.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script selects the appropriate certificate and key files to use.
+
+USER_CERT_DIR="/certificate"
+SELF_SIGNED_CERT_DIR="/build-assets/self_signed_certificates/"
+
+# Get the filenames of the user-provided .crt and .key files
+USER_CRT_FILE=$(find $USER_CERT_DIR -name "*.crt" -type f)
+USER_KEY_FILE=$(find $USER_CERT_DIR -name "*.key" -type f)
+
+# Get the filenames of the self-signed .crt and .key files
+SELF_SIGNED_CRT_FILE=$(find $SELF_SIGNED_CERT_DIR -name "*.crt" -type f)
+SELF_SIGNED_KEY_FILE=$(find $SELF_SIGNED_CERT_DIR -name "*.key" -type f)
+
+# Check if user-provided files were found
+if [ -n "$USER_CRT_FILE" ] && [ -n "$USER_KEY_FILE" ]; then
+    CRT_FILE=$USER_CRT_FILE
+    KEY_FILE=$USER_KEY_FILE
+    echo "Using user-provided certificate and key files."
+else
+    CRT_FILE=$SELF_SIGNED_CRT_FILE
+    KEY_FILE=$SELF_SIGNED_KEY_FILE
+    echo "User-provided certificate or key file not found. Using self-signed certificates."
+fi
+
+# Check if the final certificate and key files were found
+if [ -z "$CRT_FILE" ]; then
+    echo "No certificate file found"
+    exit 1
+fi
+
+if [ -z "$KEY_FILE" ]; then
+    echo "No private key file found"
+    exit 1
+fi
+
+# Export the selected certificate and key file paths
+export CRT_FILE
+export KEY_FILE

--- a/one-container-alternative/build-assets/start_daphne.sh
+++ b/one-container-alternative/build-assets/start_daphne.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script starts Daphne with the selected certificate and key files.
+
+# Generate the endpoint string for SSL
+ENDPOINT="ssl:8480:privateKey=$KEY_FILE:certKey=$CRT_FILE"
+
+echo "Starting daphne..."
+daphne --endpoint $ENDPOINT yangsuite.asgi:application
+echo "daphne started with exit code $?"

--- a/one-container-alternative/build-assets/start_environment.sh
+++ b/one-container-alternative/build-assets/start_environment.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script orchestrates the environment setup, including migration, certificate selection, validation, and starting Daphne.
+
+echo "Starting migrate_and_start script..."
+./build-assets/migrate_and_start.sh
+echo "Finished migrate_and_start script..."
+
+# Pick the right certificate
+source ./build-assets/pick_certificate.sh
+
+# Validate the selected certificate
+source ./build-assets/validate_certificate.sh
+
+# Start Daphne with HTTPS
+source ./build-assets/start_daphne.sh
+

--- a/one-container-alternative/build-assets/validate_certificate.sh
+++ b/one-container-alternative/build-assets/validate_certificate.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script validates the selected certificate and key files.
+
+# Function to check if a certificate and key are valid
+check_certificate() {
+    local crt_file=$1
+    local key_file=$2
+
+    # Check if the certificate and key match
+    openssl x509 -noout -modulus -in "$crt_file" | openssl md5
+    openssl rsa -noout -modulus -in "$key_file" | openssl md5
+
+    if [ $? -ne 0 ]; then
+        echo "Certificate and key do not match or are corrupted."
+        return 1
+    fi
+
+    # Check if the certificate is expired
+    openssl x509 -checkend 0 -noout -in "$crt_file"
+    if [ $? -ne 0 ]; then
+        echo "Certificate is expired."
+        return 1
+    fi
+
+    echo "Certificate and key are valid."
+    return 0
+}
+
+# Validate the certificate and key
+check_certificate "$CRT_FILE" "$KEY_FILE"
+if [ $? -ne 0 ]; then
+    echo "Invalid certificate or key."
+    exit 1
+fi

--- a/one-container-alternative/python_dependencies/requirements.txt
+++ b/one-container-alternative/python_dependencies/requirements.txt
@@ -1,0 +1,10 @@
+pip
+setuptools
+daphne
+twisted[http2,tls]
+wheel
+yangsuite
+yangsuite-coverage
+yangsuite-gnmi
+yangsuite-restconf
+yangsuite-grpc-telemetry


### PR DESCRIPTION
This alternative is intended for _experimentation_ and not as a direct replacement of the existing YANG Suite Docker implementation.

## Advantages

- Fewer points of failure. One container for all YANG Suite requirements.
- No user input required. Configuration settings are preset.
- No Docker Compose needed. Only Docker commands are used.
- `nginx` Server removed.
- You can provide your own certificates; otherwise, a self-signed (dummy) certificate will be used.
- HTTPs only. Port `8480` used.
- Container running as non-root user.

## Limitations

- No Backup cron job.

## Prerequisites

- `Docker`
- `Make`
